### PR TITLE
Fixed bug where abbreviations file with auto_append was not included …

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,11 +29,12 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets:
-      base_path:
-        - docs/ansible/snippets
-        - docs/automation-platform/snippets
       auto_append:
         - includes/abbreviations.md
+      base_path:
+        - .
+        - docs/ansible/snippets
+        - docs/automation-platform/snippets
   - pymdownx.details
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
…because we also set base_path parameter for other snippets, but auto_append path is relative to base_path.